### PR TITLE
Support header for mlchain client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ test/*
 htmlcov
 .coverage
 .coverage.*
-./scripts
+scripts

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test/*
 htmlcov
 .coverage
 .coverage.*
+./scripts

--- a/mlchain/client/__init__.py
+++ b/mlchain/client/__init__.py
@@ -5,7 +5,7 @@ from .http_client import HttpClient
 
 
 class Client(HttpClient, GrpcClient):
-    def __init__(self, api_key=None, api_address=None, serializer='json', timeout=5 * 60, headers=None, type='http',
+    def __init__(self, api_key=None, api_address=None, serializer='json', timeout=5 * 60, headers={}, type='http',
                  name: str = "", version: str = "", check_status=False):
         assert isinstance(type, str), "type model must be a string"
         self._api_key = api_key

--- a/mlchain/client/base.py
+++ b/mlchain/client/base.py
@@ -90,7 +90,7 @@ class MLClient:
     def __init__(self, api_key=None, api_address=None, serializer='msgpack',
                  image_encoder=None, timeout=5 * 60,
                  name=None, version='lastest',
-                 check_status=False, headers=None, **kwargs):
+                 check_status=False, headers={}, **kwargs):
         """
         Client to communicate with Mlchain server
         :api_key: Your API KEY
@@ -112,7 +112,8 @@ class MLClient:
             else:
                 api_address = mlchain.API_ADDRESS
         self.api_address = api_address
-        self.headers = headers or dict
+        # self.headers = headers or dict
+        self.headers = headers
         self.json_serializer = JsonSerializer()
 
         # Serializer initalization
@@ -191,7 +192,9 @@ class MLClient:
         def _call_post(): 
             context = {key: value
                     for (key, value) in mlchain_context.items() if key.startswith('MLCHAIN_CONTEXT_')}
-            context.update(self.headers())
+            # context.update(self.headers())
+            if type(self.headers)==dict and len(self.headers)!=0:
+                context.update(**self.headers)
 
             output = None
             try:

--- a/mlchain/client/base.py
+++ b/mlchain/client/base.py
@@ -112,7 +112,6 @@ class MLClient:
             else:
                 api_address = mlchain.API_ADDRESS
         self.api_address = api_address
-        # self.headers = headers or dict
         self.headers = headers
         self.json_serializer = JsonSerializer()
 
@@ -192,8 +191,8 @@ class MLClient:
         def _call_post(): 
             context = {key: value
                     for (key, value) in mlchain_context.items() if key.startswith('MLCHAIN_CONTEXT_')}
-            # context.update(self.headers())
-            if type(self.headers)==dict and len(self.headers)!=0:
+
+            if isinstance(self.headers, dict):
                 context.update(**self.headers)
 
             output = None
@@ -225,7 +224,9 @@ class MLClient:
         def _call_get(): 
             context = {key: value
                         for (key, value) in mlchain_context.items() if key.startswith('MLCHAIN_CONTEXT_')}
-            context.update(self.headers())
+            
+            if isinstance(self.headers, dict):
+                context.update(**self.headers)
 
             output = None
             try:

--- a/mlchain/client/base.py
+++ b/mlchain/client/base.py
@@ -37,7 +37,7 @@ from httpx import (
     WriteError,
     WriteTimeout,
 )
-from mlchain.base.exceptions import MLChainConnectionError, MLChainTimeoutError, MLChainAssertionError
+from mlchain.base.exceptions import MLChainConnectionError, MLChainTimeoutError
 
 class AsyncStorage:
     def __init__(self, function):
@@ -115,7 +115,7 @@ class MLClient:
         if isinstance(headers, dict):
             self.headers = headers
         else:
-            raise MLChainAssertionError("{} headers is invalid. Only allow dictionary header.".format(type(headers)))
+            raise AssertionError("{} headers is invalid. Only allow dictionary header.".format(type(headers)))
         self.json_serializer = JsonSerializer()
 
         # Serializer initalization


### PR DESCRIPTION
## What?
MLchain client currently does not support requests that require a specific HTTP header very well. My PR will handle that.
## Why?
HTTP request sometimes requires custom HTTP headers when called (e.g., call an API from a deployed container).
## How?
Custom headers can now be provided to the client via a `dict` when the client is initialized. E.g,
```
from mlchain.client import Client

header = {"Host": "host.default.example.com"}
client = Client(api_address="http://22.33.44.55", headers=header).model()

result = client.predict()
```