### PR TITLE
Minor release pypi bug fixed

### DIFF
--- a/.github/workflows/release_pypi.yml
+++ b/.github/workflows/release_pypi.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           python-version: 3.8
 
+      - name: Setup dependencies
+        run: pip3 install wheel
+
       - name: Build wheel
         run: |
           python3 setup.py bdist_wheel


### PR DESCRIPTION
Fixed release Pypi bug:
```
/opt/hostedtoolcache/Python/3.8.10/x64/lib/python3.8/site-packages/setuptools/dist.py:642: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help
error: invalid command 'bdist_wheel'
```